### PR TITLE
Parse MONAI model inputs and outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv/
 env/
 venv/
 ENV/

--- a/pydra/compose/monai/builder.py
+++ b/pydra/compose/monai/builder.py
@@ -15,6 +15,7 @@ from pydra.compose.base import (
 from .fields import arg, out
 from .task import MonaiTask as Task
 from .task import MonaiOutputs as Outputs
+from .spec_parser import parse_monai_spec, name_from_spec
 
 
 logger = logging.getLogger("pydra.compose.monai")
@@ -81,22 +82,16 @@ def define(
                 skip_fields=["function"],
             )
         else:
-            raise NotImplementedError(
-                "Code to read MONAI label spec and generate parsed_inputs and parsed_outputs has not been written"
-            )
+            # wrapped is a Path or str pointing to a MONAI bundle dir or metadata.json
+            spec_path = Path(wrapped) if not isinstance(wrapped, Path) else wrapped
+            class_name = name or name_from_spec(spec_path)
+            klass = None
+            parsed_inputs, parsed_outputs = parse_monai_spec(spec_path)
 
-            parsed_inputs = (
-                inputs if isinstance(inputs, dict) else {i.name: i for i in inputs}
-            )
-            parsed_outputs = (
-                outputs if isinstance(outputs, dict) else {o.name: o for o in outputs}
-            )
-
-            # Add in fields from base classes
+            # Add in base task fields (model_weights, arch)
             parsed_inputs.update(
-                {n: getattr(Task, n) for n in Task.BASE_ATTRS if n != "app"}
+                {n: getattr(Task, n) for n in Task.BASE_ATTRS}
             )
-            parsed_outputs.update({n: getattr(Outputs, n) for n in Outputs.BASE_ATTRS})
 
             parsed_inputs, parsed_outputs = ensure_field_objects(
                 arg_type=arg,

--- a/pydra/compose/monai/fields.py
+++ b/pydra/compose/monai/fields.py
@@ -32,9 +32,12 @@ class arg(base.Arg):
     name: str, optional
         The name of the field, used when specifying a list of fields instead of a mapping
         from name to field, by default it is None
+    path: str, optional
+        The key path within the MONAI bundle config that this field corresponds to
+        (e.g. "network_data_format/inputs/image"), by default it is None
     """
 
-    pass
+    path: str | None = attrs.field(default=None)
 
 
 @attrs.define(kw_only=True)
@@ -59,6 +62,9 @@ class out(base.Out):
     position : int
         The position of the output in the output list, allows for tuple unpacking of
         outputs
+    path: str, optional
+        The key path within the MONAI bundle config that this field corresponds to
+        (e.g. "network_data_format/outputs/pred"), by default it is None
     """
 
-    pass
+    path: str | None = attrs.field(default=None)

--- a/pydra/compose/monai/spec_parser.py
+++ b/pydra/compose/monai/spec_parser.py
@@ -2,6 +2,7 @@
 
 import json
 import typing as ty
+from fileformats.medimage import NiftiGzX
 from pathlib import Path
 
 from .fields import arg, out
@@ -73,7 +74,6 @@ def _map_type(spec: dict) -> type:
 
     if data_type == "image" or fmt in ("hounsfield", "segmentation"):
         try:
-            from fileformats.medimage import NiftiGzX
 
             return NiftiGzX
         except ImportError:

--- a/pydra/compose/monai/spec_parser.py
+++ b/pydra/compose/monai/spec_parser.py
@@ -1,0 +1,143 @@
+"""Parse MONAI bundle metadata.json into Pydra arg/out field definitions."""
+
+import json
+import typing as ty
+from pathlib import Path
+
+from .fields import arg, out
+
+
+def parse_monai_spec(
+    spec_path: Path | str,
+) -> tuple[dict[str, arg], dict[str, out]]:
+    """Parse a MONAI bundle metadata.json and return input/output field dicts.
+
+    Parameters
+    ----------
+    spec_path : Path | str
+        Path to a MONAI bundle ``metadata.json`` file, or to the bundle root
+        directory (in which case ``configs/metadata.json`` is loaded).
+
+    Returns
+    -------
+    parsed_inputs : dict[str, arg]
+        Mapping of field name → ``arg`` for each entry in
+        ``network_data_format.inputs``.
+    parsed_outputs : dict[str, out]
+        Mapping of field name → ``out`` for each entry in
+        ``network_data_format.outputs``.
+    """
+    spec_path = Path(spec_path)
+    if spec_path.is_dir():
+        spec_path = spec_path / "configs" / "metadata.json"
+
+    with open(spec_path) as f:
+        metadata = json.load(f)
+
+    ndf = metadata.get("network_data_format", {})
+    raw_inputs = ndf.get("inputs", {})
+    raw_outputs = ndf.get("outputs", {})
+
+    parsed_inputs: dict[str, arg] = {}
+    for key, spec in raw_inputs.items():
+        parsed_inputs[key] = arg(
+            name=key,
+            type=_map_type(spec),
+            help=_input_help(spec),
+            path=f"network_data_format/inputs/{key}",
+        )
+
+    parsed_outputs: dict[str, out] = {}
+    for key, spec in raw_outputs.items():
+        parsed_outputs[key] = out(
+            name=key,
+            type=_map_type(spec),
+            help=_output_help(spec),
+            path=f"network_data_format/outputs/{key}",
+        )
+
+    return parsed_inputs, parsed_outputs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# TODO: add modality/format-aware branching e.g. map fmt: "dicom" to a DICOM reader type instead of a generic file path
+def _map_type(spec: dict) -> type:
+    """Map a network_data_format entry to a Python/fileformats type."""
+    fmt = spec.get("format", "")
+    data_type = spec.get("type", "")
+    modality = spec.get("modality", "")
+
+    if data_type == "image" or fmt in ("hounsfield", "segmentation"):
+        try:
+            from fileformats.medimage import NiftiGzX
+
+            return NiftiGzX
+        except ImportError:
+            pass
+
+    return ty.Any
+
+
+def _input_help(spec: dict) -> str:
+    parts = []
+    if modality := spec.get("modality"):
+        parts.append(f"{modality} image")
+    if fmt := spec.get("format"):
+        parts.append(f"format: {fmt}")
+    if ch := spec.get("num_channels"):
+        parts.append(f"{ch} channel(s)")
+    if shape := spec.get("spatial_shape"):
+        parts.append(f"patch size: {shape}")
+    return ", ".join(parts) if parts else "Input image"
+
+
+def _output_help(spec: dict) -> str:
+    parts = []
+    if fmt := spec.get("format"):
+        parts.append(f"format: {fmt}")
+    if ch := spec.get("num_channels"):
+        parts.append(f"{ch} channel(s)")
+    if shape := spec.get("spatial_shape"):
+        parts.append(f"patch size: {shape}")
+    return ", ".join(parts) if parts else "Output image"
+
+
+def name_from_spec(spec_path: Path | str) -> str:
+    """Derive a valid Python class name from a MONAI bundle path or metadata.
+
+    Parameters
+    ----------
+    spec_path : Path | str
+        Path to the metadata.json or bundle root directory.
+    """
+    spec_path = Path(spec_path)
+    metadata_path = (
+        spec_path / "configs" / "metadata.json" if spec_path.is_dir() else spec_path
+    )
+
+    # Try to use the "name" field from metadata
+    try:
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+        raw_name = metadata.get("name", "")
+        if raw_name:
+            return _to_class_name(raw_name)
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    # Fall back to the directory/file stem
+    stem = spec_path.stem if spec_path.is_file() else spec_path.name
+    return _to_class_name(stem)
+
+
+def _to_class_name(s: str) -> str:
+    """Convert an arbitrary string to a valid CamelCase Python identifier."""
+    import re
+
+    # Split on non-alphanumeric characters
+    words = re.split(r"[^a-zA-Z0-9]+", s)
+    return "".join(w.capitalize() for w in words if w)

--- a/pydra/compose/monai/tests/test_monai_spec.py
+++ b/pydra/compose/monai/tests/test_monai_spec.py
@@ -1,0 +1,174 @@
+"""Tests for parsing MONAI bundle metadata into Pydra field definitions."""
+import json
+import typing as ty
+import pytest
+from pathlib import Path
+from fileformats.medimage import NiftiGzX
+from pydra.compose import monai
+from pydra.compose.monai.spec_parser import parse_monai_spec, name_from_spec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_METADATA = {
+    "name": "Whole Brain Seg UNEST",
+    "network_data_format": {
+        "inputs": {
+            "image": {
+                "type": "image",
+                "format": "hounsfield",
+                "modality": "MRI",
+                "num_channels": 1,
+                "spatial_shape": [96, 96, 96],
+            }
+        },
+        "outputs": {
+            "pred": {
+                "type": "image",
+                "format": "segmentation",
+                "num_channels": 133,
+                "spatial_shape": [96, 96, 96],
+            }
+        },
+    },
+}
+
+
+@pytest.fixture
+def metadata_json(tmp_path: Path) -> Path:
+    p = tmp_path / "metadata.json"
+    p.write_text(json.dumps(MINIMAL_METADATA))
+    return p
+
+
+@pytest.fixture
+def bundle_dir(tmp_path: Path) -> Path:
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "metadata.json").write_text(json.dumps(MINIMAL_METADATA))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# parse_monai_spec tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_inputs_from_metadata_json(metadata_json: Path):
+    parsed_inputs, _ = parse_monai_spec(metadata_json)
+    assert "image" in parsed_inputs
+    field = parsed_inputs["image"]
+    assert field.name == "image"
+    assert field.type is NiftiGzX
+    assert field.path == "network_data_format/inputs/image"
+
+
+def test_parse_outputs_from_metadata_json(metadata_json: Path):
+    _, parsed_outputs = parse_monai_spec(metadata_json)
+    assert "pred" in parsed_outputs
+    field = parsed_outputs["pred"]
+    assert field.name == "pred"
+    assert field.type is NiftiGzX
+    assert field.path == "network_data_format/outputs/pred"
+
+
+def test_parse_from_bundle_dir(bundle_dir: Path):
+    parsed_inputs, parsed_outputs = parse_monai_spec(bundle_dir)
+    assert "image" in parsed_inputs
+    assert "pred" in parsed_outputs
+
+
+def test_parse_unknown_type_falls_back_to_any(tmp_path: Path):
+    metadata = {
+        "network_data_format": {
+            "inputs": {"feat": {"type": "tensor", "format": "embedding"}},
+            "outputs": {},
+        }
+    }
+    p = tmp_path / "metadata.json"
+    p.write_text(json.dumps(metadata))
+    parsed_inputs, _ = parse_monai_spec(p)
+    assert parsed_inputs["feat"].type is ty.Any
+
+
+def test_input_help_contains_modality(metadata_json: Path):
+    parsed_inputs, _ = parse_monai_spec(metadata_json)
+    assert "MRI" in parsed_inputs["image"].help
+
+
+def test_output_help_contains_format(metadata_json: Path):
+    _, parsed_outputs = parse_monai_spec(metadata_json)
+    assert "segmentation" in parsed_outputs["pred"].help
+
+
+# ---------------------------------------------------------------------------
+# name_from_spec tests
+# ---------------------------------------------------------------------------
+
+
+def test_name_from_spec_uses_metadata_name(metadata_json: Path):
+    assert name_from_spec(metadata_json) == "WholeBrainSegUnest"
+
+
+def test_name_from_spec_uses_dir_name(tmp_path: Path):
+    # No metadata, just a bare directory
+    name = name_from_spec(tmp_path)
+    assert name  # non-empty
+    assert name.isidentifier()
+
+
+# ---------------------------------------------------------------------------
+# monai.define integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_define_from_metadata_json_creates_task_class(metadata_json: Path):
+    TaskCls = monai.define(metadata_json)
+    assert TaskCls is not None
+    field_names = [f.name for f in TaskCls.__attrs_attrs__]
+    assert "image" in field_names
+    assert "model_weights" in field_names
+
+
+def test_define_from_metadata_json_outputs_have_pred(metadata_json: Path):
+    TaskCls = monai.define(metadata_json)
+    output_field_names = [f.name for f in TaskCls.Outputs.__attrs_attrs__]
+    assert "pred" in output_field_names
+
+
+def test_define_preserves_path_on_arg(metadata_json: Path):
+    TaskCls = monai.define(metadata_json)
+    image_field = next(f for f in TaskCls.__attrs_attrs__ if f.name == "image")
+    # path is stored inside the pydra field spec under __PYDRA_METADATA__
+    pydra_meta = image_field.metadata["__PYDRA_METADATA__"]
+    assert pydra_meta.path == "network_data_format/inputs/image"
+
+
+def test_define_preserves_path_on_out(metadata_json: Path):
+    TaskCls = monai.define(metadata_json)
+    pred_field = next(
+        f for f in TaskCls.Outputs.__attrs_attrs__ if f.name == "pred"
+    )
+    pydra_meta = pred_field.metadata["__PYDRA_METADATA__"]
+    assert pydra_meta.path == "network_data_format/outputs/pred"
+
+
+def test_define_class_name_from_metadata(metadata_json: Path):
+    TaskCls = monai.define(metadata_json)
+    assert TaskCls.__name__ == "WholeBrainSegUnest"
+
+
+def test_define_explicit_name_overrides_metadata(metadata_json: Path):
+    TaskCls = monai.define(metadata_json, name="MyCustomTask")
+    assert TaskCls.__name__ == "MyCustomTask"
+
+
+def test_arg_path_attribute_direct():
+    """arg and out accept a path kwarg and store it."""
+    a = monai.arg(name="T1w", type=NiftiGzX, path="anat/T1w")
+    assert a.path == "anat/T1w"
+
+    o = monai.out(name="mask", type=NiftiGzX, path="anat/mask")
+    assert o.path == "anat/mask"


### PR DESCRIPTION
* initial step for setting up a pydra workflow for running MONAI Zoo models in XNAT pipelines
* created a separate spec_parser and hooked it up to the builder
* for now just accepts a path to a MONAI model's metadata.json file and parses the network_data_format to arg/out dicts
* currently defaults image data types to NIFTI, but can be extended for other types e.g. DICOM
*  added tests
* still to do: task._run, task._from_job - load weights + arch, run inference, write outputs + populate MonaiOutputs fields